### PR TITLE
feature/0001:

### DIFF
--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -987,8 +987,8 @@ namespace Server.Mobiles
 			{
 				Effects.SendLocationEffect( blast1, target.Map, 0x10D3, 30, 10, 0, 0 );
 				target.PlaySound( 0x62D );
-				double webbed = ((double)(this.Fame/200));
-					if ( webbed > 15.0 ){ webbed = 15.0; }
+				// feature/0001 - caps paralize duration for what was set in MySettings.S_paralyzeDuration
+				double webbed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? ((double)(this.Fame/200)) : MySettings.S_paralyzeDuration;
 				target.Paralyze( TimeSpan.FromSeconds( webbed ) );
 			}
 			else if ( form == 7 ) // GIANT STONES AND LOGS ------------------------------------------------------------------------------------------
@@ -1273,8 +1273,8 @@ namespace Server.Mobiles
 				Effects.PlaySound( target.Location, target.Map, 0x64F );
 				BreathDistance = 3;
 
-				double weed = ((double)(this.Fame/200));
-					if ( weed > 15.0 ){ weed = 15.0; }
+				// feature/0001 - caps paralize duration for what was set in MySettings.S_paralyzeDuration.
+				double weed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? ((double)(this.Fame/200)) : MySettings.S_paralyzeDuration;
 				target.Paralyze( TimeSpan.FromSeconds( weed ) );
 			}
 			else if ( form == 35 ) // SMALL WEED BREATH ---------------------------------------------------------------------------------------------
@@ -1283,8 +1283,8 @@ namespace Server.Mobiles
 				Effects.PlaySound( target.Location, target.Map, 0x64F );
 				BreathDistance = 2;
 
-				double weed = ((double)(this.Fame/200));
-					if ( weed > 15.0 ){ weed = 15.0; }
+				// feature/0001 - caps paralize duration for what was set in MySettings.S_paralyzeDuration.
+				double weed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? ((double)(this.Fame/200)) : MySettings.S_paralyzeDuration;
 				target.Paralyze( TimeSpan.FromSeconds( weed ) );
 			}
 			else if ( form == 36 ) // ACID SPLASH ---------------------------------------------------------------------------------------------------
@@ -1302,7 +1302,9 @@ namespace Server.Mobiles
 				Point3D wrapped = new Point3D( ( target.X ), ( target.Y ), (target.Z+2) );
 				Effects.SendLocationEffect( wrapped, target.Map, 0x23AF, 30, 10, 0, 0 );
 				target.PlaySound( 0x5D2 );
-				target.Paralyze( TimeSpan.FromSeconds( 5.0 ) );
+				// feature/0001 - caps paralize duration for what was set in MySettings.S_paralyzeDuration.
+				double wrap = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? ((double)(this.Fame/200)) : MySettings.S_paralyzeDuration;
+				target.Paralyze( TimeSpan.FromSeconds(wrap) );
 			}
 			else if ( form == 38 ) // SMALL STEAM BREATH --------------------------------------------------------------------------------------------
 			{

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -443,7 +443,9 @@ namespace Server
 		public static int S_SpawnMin = 45;
 		public static int S_SpawnMax = 60;
 
-
+	// This settings controls the limit in seconds by which you can be paralyzed by a monster. 
+	// The default is 15 seconds.
+		public static double S_paralyzeDuration = 15.0;
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- adds an option to Settings.cs that determines how long a paralyze effect can last on a player; the default behavior was all the way up to 15 seconds, which made some areas (like the Terathan keep) a chore to navigate, this gives the server admin the option to control how long in seconds the